### PR TITLE
AMB-1103: Removal of Name Mangling in Non-OOP Python Code

### DIFF
--- a/mediation_service/mediation/client_credentials.py
+++ b/mediation_service/mediation/client_credentials.py
@@ -10,8 +10,7 @@ class AuthClientCredentials:
     _client_assertion_type: str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
     def __init__(self, auth_url: str, private_key_content: str = "", client_id: str = "", aud: str = "",
-                 headers: dict = None,
-                 alg="RS512") -> None:
+                 headers: dict = None, alg="RS512") -> None:
         self._auth_url = auth_url
         self._client_id = client_id
         self._aud = aud

--- a/mediation_service/mediation/client_credentials.py
+++ b/mediation_service/mediation/client_credentials.py
@@ -7,26 +7,26 @@ from fastapi import HTTPException
 
 
 class AuthClientCredentials:
-    __client_assertion_type: str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+    _client_assertion_type: str = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
     def __init__(self, auth_url: str, private_key_content: str = "", client_id: str = "", aud: str = "",
                  headers: dict = None,
                  alg="RS512") -> None:
-        self.__auth_url = auth_url
-        self.__client_id = client_id
-        self.__aud = aud
-        self.__headers = headers
-        self.__alg = alg
-        self.__signing_key = self.__reformat_private_key(private_key_content)
+        self._auth_url = auth_url
+        self._client_id = client_id
+        self._aud = aud
+        self._headers = headers
+        self._alg = alg
+        self._signing_key = self._reformat_private_key(private_key_content)
 
     def get_access_token(self):
-        _jwt = self.__create_jwt(self.__signing_key, self.__client_id, self.__aud, self.__headers, self.__alg)
+        _jwt = self._create_jwt(self._signing_key, self._client_id, self._aud, self._headers, self._alg)
         data = {
             "client_assertion": _jwt,
-            "client_assertion_type": self.__client_assertion_type,
+            "client_assertion_type": self._client_assertion_type,
             "grant_type": "client_credentials",
         }
-        res = requests.post(f"{self.__auth_url}/token", data)
+        res = requests.post(f"{self._auth_url}/token", data)
 
         if res.status_code != 200:
             raise HTTPException(status_code=res.status_code, detail="Client credentials failed.")
@@ -34,7 +34,7 @@ class AuthClientCredentials:
         return res.json()["access_token"]
 
     @staticmethod
-    def __create_jwt(signing_key: str, client_id: str, aud: str, headers: dict, alg="RS512", expiry_sec=5) -> str:
+    def _create_jwt(signing_key: str, client_id: str, aud: str, headers: dict, alg="RS512", expiry_sec=5) -> str:
         claims = {
             "sub": client_id,
             "iss": client_id,
@@ -46,7 +46,7 @@ class AuthClientCredentials:
         return jwt.encode(claims, signing_key, headers=headers, algorithm=alg)
 
     @staticmethod
-    def __reformat_private_key(key):
+    def _reformat_private_key(key):
         """Private key that is passed via environment variable replaces new-lines with spaces.
         This function fixes the issue"""
 

--- a/mediation_service/mediation/fhir_converter_client.py
+++ b/mediation_service/mediation/fhir_converter_client.py
@@ -3,11 +3,11 @@ from request_helpers import make_post_request
 
 class FhirConverter:
     def __init__(self, url: str, env: str):
-        self.__env = env
-        self.__url = url
+        self._env = env
+        self._url = url
 
     def convert(self, bundle: dict, access_token: str):
-        url = f"https://{self.__url}/fhir-converter/$convert"
+        url = f"https://{self._url}/fhir-converter/$convert"
 
         headers = {
             "Authorization": f"Bearer {access_token}",

--- a/mediation_service/mediation/pds_client.py
+++ b/mediation_service/mediation/pds_client.py
@@ -5,8 +5,8 @@ from request_helpers import make_get_request
 
 class PdsClient:
     def __init__(self, url: str, env: str) -> None:
-        self.__env = env
-        self.__url = url
+        self._env = env
+        self._url = url
 
     def get_ods_for_nhs_number(self, nhs_number, access_token):
 
@@ -14,14 +14,14 @@ class PdsClient:
             "X-Request-ID": str(uuid4()),
             "Authorization": f"Bearer {access_token}",
         }
-        url = f"https://{self.__url}/personal-demographics/FHIR/R4/Patient/{nhs_number}"
+        url = f"https://{self._url}/personal-demographics/FHIR/R4/Patient/{nhs_number}"
 
         res = make_get_request(call_name="PDS", url=url, headers=headers)
 
-        return self.__get_ods(res.json())
+        return self._get_ods(res.json())
 
     @staticmethod
-    def __get_ods(patient: dict) -> str:
+    def _get_ods(patient: dict) -> str:
         def is_ods_extension(gp):
             return (gp["identifier"]["system"] == "https://fhir.nhs.uk/Id/ods-organization-code")
 

--- a/mediation_service/mediation/prepare_ssp_response.py
+++ b/mediation_service/mediation/prepare_ssp_response.py
@@ -12,10 +12,10 @@ from jsonpath_rw import parse
 
 
 def prepare_ssp_response(ssp_response: dict) -> dict:
-    __transform_allergy_local_references(ssp_response)
-    operationoutcome = __filter_warnings_to_operationoutcome(ssp_response)
-    __filter_non_allergy_intolerance(ssp_response)
-    __remove_fhir_comment(ssp_response)
+    _transform_allergy_local_references(ssp_response)
+    operationoutcome = _filter_warnings_to_operationoutcome(ssp_response)
+    _filter_non_allergy_intolerance(ssp_response)
+    _remove_fhir_comment(ssp_response)
 
     if operationoutcome:
         operationoutcome_object = {"resource": operationoutcome.as_json()}
@@ -25,7 +25,7 @@ def prepare_ssp_response(ssp_response: dict) -> dict:
     return ssp_response
 
 
-def __filter_warnings_to_operationoutcome(ssp_response: dict) -> OperationOutcome:
+def _filter_warnings_to_operationoutcome(ssp_response: dict) -> OperationOutcome:
     query = parse("`this`.entry[*].resource.resourceType")
     matches = query.find(ssp_response)
 
@@ -41,14 +41,14 @@ def __filter_warnings_to_operationoutcome(ssp_response: dict) -> OperationOutcom
                     "-ListWarningCode-1"
                 ):
                     operation_outcome_list.append(
-                        __build_operationoutcome_issue(extension)
+                        _build_operationoutcome_issue(extension)
                     )
 
     if operation_outcome_list:
-        return __build_operationoutcome(operation_outcome_list)
+        return _build_operationoutcome(operation_outcome_list)
 
 
-def __build_operationoutcome_issue(extension: Extension) -> OperationOutcomeIssue:
+def _build_operationoutcome_issue(extension: Extension) -> OperationOutcomeIssue:
     op_outcome_issue = OperationOutcomeIssue()
     codeable_concept = CodeableConcept()
     coding_list = []
@@ -94,7 +94,7 @@ def __build_operationoutcome_issue(extension: Extension) -> OperationOutcomeIssu
     return op_outcome_issue
 
 
-def __build_operationoutcome(operation_outcome_list) -> OperationOutcome:
+def _build_operationoutcome(operation_outcome_list) -> OperationOutcome:
     operationoutcome = OperationOutcome()
     meta = Meta()
     fhir_date = FHIRDate()
@@ -111,7 +111,7 @@ def __build_operationoutcome(operation_outcome_list) -> OperationOutcome:
     return operationoutcome
 
 
-def __transform_patient(ssp_response: dict) -> dict:
+def _transform_patient(ssp_response: dict) -> dict:
     patient_dict_to_return = {}
     query = parse("`this`.entry[*].resource.resourceType")
     matches = query.find(ssp_response)
@@ -135,8 +135,8 @@ def __transform_patient(ssp_response: dict) -> dict:
     return patient_dict_to_return
 
 
-def __transform_allergy_local_references(ssp_response: dict):
-    patient_list = __transform_patient(ssp_response)
+def _transform_allergy_local_references(ssp_response: dict):
+    patient_list = _transform_patient(ssp_response)
 
     query = parse("`this`.entry[*].resource.resourceType")
     matches = query.find(ssp_response)
@@ -154,7 +154,7 @@ def __transform_allergy_local_references(ssp_response: dict):
                 ] = patient_list.get(patient_id[1], patient_ref)
 
 
-def __filter_non_allergy_intolerance(ssp_response: dict):
+def _filter_non_allergy_intolerance(ssp_response: dict):
     query = parse("`this`.entry[*].resource.resourceType")
     matches = query.find(ssp_response)
 
@@ -168,7 +168,7 @@ def __filter_non_allergy_intolerance(ssp_response: dict):
         ssp_response["entry"].remove(item)
 
 
-def __remove_fhir_comment(ssp_response: dict):
+def _remove_fhir_comment(ssp_response: dict):
     query = parse("`this`..fhir_comments")
     matches = query.find(ssp_response)
 

--- a/mediation_service/mediation/prepare_ssp_response.py
+++ b/mediation_service/mediation/prepare_ssp_response.py
@@ -157,7 +157,7 @@ def _transform_allergy_local_references(ssp_response: dict):
                     "reference"
                 ] = patient_list.get(patient_id[1], patient_ref)
 
-                
+
 def _extract_resolved_allergies(ssp_response: dict) -> list:
     """
     Select resolved allergy intolerance resources from Ended allergies list

--- a/mediation_service/mediation/request_helpers.py
+++ b/mediation_service/mediation/request_helpers.py
@@ -8,9 +8,7 @@ def make_get_request(call_name: str, url, headers=None, params=None):
     return res
 
 
-def make_post_request(
-    call_name: str, url, headers=None, data=None, json=None, verify=True
-):
+def make_post_request(call_name: str, url, headers=None, data=None, json=None, verify=True):
     res = requests.post(url, headers=headers, data=data, json=json, verify=verify)
     handle_error(res, call_name)
     return res

--- a/mediation_service/mediation/sds_client.py
+++ b/mediation_service/mediation/sds_client.py
@@ -3,13 +3,13 @@ from request_helpers import make_get_request
 
 class SdsClient:
     def __init__(self, client_id: str, apigee_url: str) -> None:
-        self.__client_id = client_id
-        self.__apigee_url = apigee_url
+        self._client_id = client_id
+        self._apigee_url = apigee_url
 
     def get_toASID(self, ods_code):
-        url = f"https://{self.__apigee_url}/spine-directory/FHIR/R4/Device"
+        url = f"https://{self._apigee_url}/spine-directory/FHIR/R4/Device"
 
-        headers = {"apikey": self.__client_id}
+        headers = {"apikey": self._client_id}
 
         params = {
             "organization": f"https://fhir.nhs.uk/Id/ods-organization-code|{ods_code}",
@@ -20,9 +20,9 @@ class SdsClient:
             call_name="SDS get_toASID", url=url, headers=headers, params=params
         )
 
-        return self.__get_toAsid(res.json())
+        return self._get_toAsid(res.json())
 
-    def __get_toAsid(self, bundle) -> str:
+    def _get_toAsid(self, bundle) -> str:
         if bundle["total"] == 0:
             return None
         else:
@@ -36,9 +36,9 @@ class SdsClient:
             return asidId
 
     def get_URL(self, ods_code):
-        url = f"https://{self.__apigee_url}/spine-directory/FHIR/R4/Endpoint"
+        url = f"https://{self._apigee_url}/spine-directory/FHIR/R4/Endpoint"
 
-        headers = {"apikey": self.__client_id}
+        headers = {"apikey": self._client_id}
 
         params = {
             "organization": f"https://fhir.nhs.uk/Id/ods-organization-code|{ods_code}",
@@ -49,9 +49,9 @@ class SdsClient:
             call_name="SDS get_URL", url=url, headers=headers, params=params
         )
 
-        return self.__get_URL(res.json())
+        return self._get_URL(res.json())
 
-    def __get_URL(self, bundle) -> str:
+    def _get_URL(self, bundle) -> str:
         if bundle["total"] == 0:
             return None
         else:

--- a/mediation_service/mediation/ssp_client.py
+++ b/mediation_service/mediation/ssp_client.py
@@ -22,14 +22,14 @@ class SspClient:
             "Authorization": f"Bearer {create_orange_jwt(ods['to_ASID'])}"
         }
 
-        _body = self.__get_orange_payload()
+        _body = self._get_orange_payload()
         # ODS code on the request is hardcoded --- need to be changed
         res = make_post_request(call_name="SSP get allergy intolerance bundle", url=url, headers=headers, data=_body, verify=False)
 
         return res.json()
 
     @staticmethod
-    def __get_orange_payload() -> str:
+    def _get_orange_payload() -> str:
         dir_path = os.path.dirname(os.path.realpath(__file__))
         file_path = os.path.join(dir_path, 'getstructuredrecord_payload.json')
 

--- a/tests/configuration/cmd_options.py
+++ b/tests/configuration/cmd_options.py
@@ -49,12 +49,12 @@ def create_cmd_options(get_cmd_opt_value) -> dict:
         if opt["required"] and not value:
             raise Exception(f"Option {opt_name} is required but it's value is empty or null")
 
-    __validate_options(cmd_options)
+    _validate_options(cmd_options)
 
     return cmd_options
 
 
-def __validate_options(cmd_options):
+def _validate_options(cmd_options):
     """Whether some values are required or not might change depending on deployment environment"""
     current_env = cmd_options["--apigee-environment"]
     access_token = cmd_options["--access-token"]


### PR DESCRIPTION
## Summary
* Replaced double leading underscore variable/function names (name mangling) with single leading underscore versions.

Although prefixing a function name with a double underscore appears to make the function private, Python was not designed with public/private/protected access modifiers in mind - the double leading underscore is used to create a class local reference. 

It's more appropriate to replace the leading double underscores of these non-public parts of the API with a leading single underscore, as is Python convention to indicate a private variable whilst still allowing access to the functions and not modifying the function identifiers.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner

## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
